### PR TITLE
feat: Add image manifest system for faster deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,28 @@ jobs:
         run: yarn install
         working-directory: app
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Download cached optimized images from S3
+        run: |
+          echo "Downloading cached images and manifest from S3..."
+          aws s3 sync s3://${{ secrets.S3_BUCKET_NAME }}/images ./public/images \
+            --exclude "*" \
+            --include "*.webp" \
+            --include "*.avif" \
+            --include ".image-manifest.json" \
+            --only-show-errors || echo "No cached images found (first deploy?)"
+
+          CACHED_COUNT=$(find ./public/images \( -name "*.webp" -o -name "*.avif" \) 2>/dev/null | wc -l)
+          echo "Downloaded $CACHED_COUNT cached optimized images"
+        working-directory: app
+        continue-on-error: true
+
       - name: Validate image references
         run: yarn images:validate
         working-directory: app
@@ -45,13 +67,6 @@ jobs:
           fi
           ls -la out
         working-directory: app
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Sync images to S3 (with long cache headers)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,12 @@ web_modules/
 .next
 out
 
+# Image optimization manifest (synced via S3, not git)
+.image-manifest.json
+
+# Archived/unused images (for review, not deployed)
+app/public/images/_archive/
+
 # Nuxt.js build / generate output
 .nuxt
 dist

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint . --fix",
     "format": "prettier --write .",
     "images:validate": "node scripts/images/validate.js",
-    "images:optimize": "node scripts/images/optimize.js"
+    "images:optimize": "node scripts/images/optimize.js",
+    "images:archive": "node scripts/images/archive-orphans.js"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.16",

--- a/app/scripts/images/archive-orphans.js
+++ b/app/scripts/images/archive-orphans.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Archive Orphaned Images CLI
+ *
+ * Moves orphaned images (not referenced in data files) to _archive/ folder.
+ * The _archive/ folder is git-ignored and won't be deployed.
+ *
+ * Usage: yarn images:archive
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { glob } = require('glob');
+
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const IMAGES_DIR = path.join(ROOT_DIR, 'public/images');
+const ARCHIVE_DIR = path.join(IMAGES_DIR, '_archive');
+const DATA_DIR = path.join(ROOT_DIR, 'src/data');
+
+// ANSI colors
+const colors = {
+  green: (text) => `\x1b[32m${text}\x1b[0m`,
+  yellow: (text) => `\x1b[33m${text}\x1b[0m`,
+  red: (text) => `\x1b[31m${text}\x1b[0m`,
+  cyan: (text) => `\x1b[36m${text}\x1b[0m`,
+  bold: (text) => `\x1b[1m${text}\x1b[0m`,
+};
+
+async function getImageFiles() {
+  const pattern = path.join(IMAGES_DIR, '**/*.{jpg,jpeg,png,gif,webp,avif,JPG,JPEG,PNG}');
+  const files = await glob(pattern, {
+    nodir: true,
+    ignore: ['**/_archive/**'],
+  });
+  return new Set(files.map((f) => `/images/${path.relative(IMAGES_DIR, f)}`));
+}
+
+function getImageReferences() {
+  const references = new Set();
+  const dataFiles = ['data.tsx'];
+
+  for (const file of dataFiles) {
+    const filePath = path.join(DATA_DIR, file);
+    if (!fs.existsSync(filePath)) continue;
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split('\n');
+
+    lines.forEach((line) => {
+      const matches = line.matchAll(/['"]\/images\/[^'"]+['"]/g);
+      for (const match of matches) {
+        const imagePath = match[0].slice(1, -1);
+        references.add(imagePath);
+      }
+    });
+  }
+
+  return references;
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function main() {
+  console.log(colors.bold('\n=== Archive Orphaned Images ===\n'));
+
+  const existingImages = await getImageFiles();
+  const references = getImageReferences();
+
+  // Find orphaned images (exist but not referenced)
+  const orphanedImages = [...existingImages].filter((img) => !references.has(img));
+
+  if (orphanedImages.length === 0) {
+    console.log(colors.green('No orphaned images found. Nothing to archive.'));
+    process.exit(0);
+  }
+
+  console.log(`Found ${colors.yellow(orphanedImages.length)} orphaned images to archive.\n`);
+
+  // Create archive directory
+  ensureDir(ARCHIVE_DIR);
+
+  let movedCount = 0;
+  let errorCount = 0;
+
+  for (const imgPath of orphanedImages.sort()) {
+    // imgPath is like /images/gallery/photo.jpg
+    // We need to move from public/images/gallery/photo.jpg to public/images/_archive/gallery/photo.jpg
+    const relativePath = imgPath.replace('/images/', '');
+    const sourcePath = path.join(IMAGES_DIR, relativePath);
+    const destPath = path.join(ARCHIVE_DIR, relativePath);
+
+    try {
+      // Ensure destination subdirectory exists
+      ensureDir(path.dirname(destPath));
+
+      // Move the file
+      fs.renameSync(sourcePath, destPath);
+      console.log(`  ${colors.cyan('→')} ${relativePath}`);
+      movedCount++;
+    } catch (err) {
+      console.log(`  ${colors.red('✗')} ${relativePath}: ${err.message}`);
+      errorCount++;
+    }
+  }
+
+  // Summary
+  console.log(colors.bold('\n=== Summary ==='));
+  console.log(`${colors.green('Moved')}: ${movedCount} images`);
+  if (errorCount > 0) {
+    console.log(`${colors.red('Errors')}: ${errorCount} images`);
+  }
+  console.log(`\nArchived images are in: ${colors.cyan('public/images/_archive/')}`);
+  console.log('This folder is git-ignored and will not be deployed.');
+  console.log('\nTo restore an image, move it back to its original location.');
+}
+
+main().catch((err) => {
+  console.error(colors.red('Error:'), err.message);
+  process.exit(1);
+});

--- a/app/scripts/images/optimize.js
+++ b/app/scripts/images/optimize.js
@@ -14,6 +14,7 @@ const { glob } = require('glob');
 
 const ROOT_DIR = path.resolve(__dirname, '../..');
 const IMAGES_DIR = path.join(ROOT_DIR, 'public/images');
+const MANIFEST_PATH = path.join(IMAGES_DIR, '.image-manifest.json');
 
 // ANSI colors
 const colors = {
@@ -42,20 +43,45 @@ function formatFileSize(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-async function optimizeImage(sharp, inputPath) {
+function loadManifest() {
+  try {
+    if (fs.existsSync(MANIFEST_PATH)) {
+      return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    }
+  } catch (error) {
+    console.log(colors.yellow(`Warning: Could not load manifest: ${error.message}`));
+  }
+  return {};
+}
+
+function saveManifest(manifest) {
+  try {
+    fs.writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2));
+  } catch (error) {
+    console.log(colors.yellow(`Warning: Could not save manifest: ${error.message}`));
+  }
+}
+
+async function optimizeImage(sharp, inputPath, manifest) {
   const results = [];
   const dir = path.dirname(inputPath);
   const ext = path.extname(inputPath);
   const basename = path.basename(inputPath, ext);
+  const manifestKey = path.relative(IMAGES_DIR, inputPath);
 
   try {
     const image = sharp(inputPath);
     const metadata = await image.metadata();
     const originalSize = fs.statSync(inputPath).size;
 
+    // Check if source file size matches manifest (detect replaced images)
+    const manifestSize = manifest[manifestKey];
+    const sizeChanged = manifestSize !== originalSize;
+
     // Generate WebP version
     const webpPath = path.join(dir, `${basename}.webp`);
-    if (!fs.existsSync(webpPath)) {
+    const webpExists = fs.existsSync(webpPath);
+    if (!webpExists || sizeChanged) {
       await sharp(inputPath).webp({ quality: WEBP_QUALITY }).toFile(webpPath);
 
       const webpSize = fs.statSync(webpPath).size;
@@ -65,12 +91,14 @@ async function optimizeImage(sharp, inputPath) {
         format: 'WebP',
         size: webpSize,
         savings: `${savings}%`,
+        reason: sizeChanged && webpExists ? 'source changed' : 'new',
       });
     }
 
     // Generate AVIF version
     const avifPath = path.join(dir, `${basename}.avif`);
-    if (!fs.existsSync(avifPath)) {
+    const avifExists = fs.existsSync(avifPath);
+    if (!avifExists || sizeChanged) {
       await sharp(inputPath).avif({ quality: AVIF_QUALITY }).toFile(avifPath);
 
       const avifSize = fs.statSync(avifPath).size;
@@ -80,11 +108,13 @@ async function optimizeImage(sharp, inputPath) {
         format: 'AVIF',
         size: avifSize,
         savings: `${savings}%`,
+        reason: sizeChanged && avifExists ? 'source changed' : 'new',
       });
     }
 
     return {
       input: inputPath,
+      manifestKey,
       originalSize,
       width: metadata.width,
       height: metadata.height,
@@ -115,6 +145,13 @@ async function main() {
   const sourceImages = await getSourceImages();
   console.log(`Found ${sourceImages.length} source images to optimize\n`);
 
+  // Load manifest for tracking source file sizes
+  const manifest = loadManifest();
+  const manifestEntries = Object.keys(manifest).length;
+  if (manifestEntries > 0) {
+    console.log(`Loaded manifest with ${manifestEntries} entries\n`);
+  }
+
   let totalOriginalSize = 0;
   let totalOptimizedSize = 0;
   let newFilesCreated = 0;
@@ -124,7 +161,7 @@ async function main() {
     const relativePath = path.relative(ROOT_DIR, imagePath);
     process.stdout.write(`Processing ${colors.cyan(relativePath)}... `);
 
-    const result = await optimizeImage(sharp, imagePath);
+    const result = await optimizeImage(sharp, imagePath, manifest);
 
     if (result.error) {
       console.log(colors.red(`Error: ${result.error}`));
@@ -134,11 +171,17 @@ async function main() {
 
     totalOriginalSize += result.originalSize;
 
+    // Update manifest with current file size
+    manifest[result.manifestKey] = result.originalSize;
+
     if (result.outputs.length === 0) {
       console.log(colors.dim('(already optimized)'));
     } else {
       const outputInfo = result.outputs
-        .map((o) => `${o.format}: ${colors.green(o.savings)} smaller`)
+        .map((o) => {
+          const reasonTag = o.reason === 'source changed' ? colors.yellow(' [source changed]') : '';
+          return `${o.format}: ${colors.green(o.savings)} smaller${reasonTag}`;
+        })
         .join(', ');
       console.log(outputInfo);
       newFilesCreated += result.outputs.length;
@@ -148,6 +191,9 @@ async function main() {
       }
     }
   }
+
+  // Save updated manifest
+  saveManifest(manifest);
 
   // Summary
   console.log(colors.bold('\n=== Summary ==='));


### PR DESCRIPTION
- Add manifest-based tracking to optimize.js to detect source file changes
- Download cached optimized images from S3 before optimization
- Only re-optimize images when source file size changes
- Add archive-orphans.js script to move unreferenced images
- Update .gitignore for manifest and archive folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)